### PR TITLE
feat(tutorial): integrate django-polymorphic for polymorphic tutorial…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -728,6 +728,20 @@ Django = ">=4.2"
 typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "django-polymorphic"
+version = "3.1.0"
+description = "Seamless polymorphic inheritance for Django models"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-polymorphic-3.1.0.tar.gz", hash = "sha256:d6955b5308bf6e41dcb22ba7c96f00b51dfa497a8a5ab1e9c06c7951bf417bf8"},
+    {file = "django_polymorphic-3.1.0-py3-none-any.whl", hash = "sha256:08bc4f4f4a773a19b2deced5a56deddd1ef56ebd15207bf4052e2901c25ef57e"},
+]
+
+[package.dependencies]
+Django = ">=2.1"
+
+[[package]]
 name = "django-sage-tools"
 version = "0.3.5"
 description = "Reusable, generic mixins for Django"
@@ -1643,6 +1657,26 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "75.6.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "setuptools-75.6.0-py3-none-any.whl", hash = "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d"},
+    {file = "setuptools-75.6.0.tar.gz", hash = "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.7.0)"]
+core = ["importlib_metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (>=1.12,<1.14)", "pytest-mypy"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -2325,4 +2359,4 @@ docs = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "6ad420b8da2d00f8f32d37c081bdfdab9b804eca5dffddaa85a9993ebcf3d1a1"
+content-hash = "28d6cc390ab39846f0769730270f34b2be29f0bae44ef31eff60413c01651a4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django_sage_ticket"
-version = "0.1.9"
+version = "0.1.10"
 description = "A Django-based ticketing system"
 authors = ["Radin Ghaheremani <radin@sageteam.org>","Sepehr Akbarzadeh <sepehr@sageteam.org>"]
 readme = "README.md"
@@ -21,6 +21,8 @@ django-import-export = "^4.3.3"
 django-ckeditor-5 = "^0.2.15"
 sorl-thumbnail = "^12.11.0"
 readtime = "^3.0.0"
+django-polymorphic = "^3.1.0"
+setuptools = "^75.6.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/sage_ticket/admin/__init__.py
+++ b/sage_ticket/admin/__init__.py
@@ -3,7 +3,7 @@ from .comment import CommentAdmin
 from .department import DepartmentAdmin
 from .issue import IssueAdmin
 from .faq import FaqCategoryAdmin, FaqAdmin
-from .tutorial import TutorialAdmin
+from .tutorial import TutorialAdmin, VideoTutorial, PictureTutorial
 from .tutorial_faq import TutorialFaqAdmin
 from .category import TutorialCategoryAdmin
 from .tag import TutorialTagAdmin
@@ -16,6 +16,8 @@ __all__ = [
     "FaqCategoryAdmin",
     "FaqAdmin",
     "TutorialAdmin",
+    "PictureTutorial",
+    "VideoTutorial",
     "TutorialFaqAdmin",
     "TutorialCategoryAdmin",
     "TutorialTagAdmin",

--- a/sage_ticket/admin/tutorial.py
+++ b/sage_ticket/admin/tutorial.py
@@ -4,8 +4,9 @@ from django.utils.translation import gettext_lazy as _
 from sorl.thumbnail.admin import AdminImageMixin
 from import_export.admin import ImportExportModelAdmin
 from modeltranslation.admin import TabbedTranslationAdmin, TranslationTabularInline
+from polymorphic.admin import PolymorphicParentModelAdmin, PolymorphicChildModelAdmin
 
-from sage_ticket.models import Tutorial, TutorialFaq
+from sage_ticket.models import Tutorial, TutorialFaq, VideoTutorial, PictureTutorial
 from sage_ticket.resources import TutorialResource
 
 
@@ -15,7 +16,12 @@ class TutorialFaqInline(TranslationTabularInline):
 
 
 @admin.register(Tutorial)
-class TutorialAdmin(ImportExportModelAdmin, TabbedTranslationAdmin, AdminImageMixin):
+class TutorialAdmin(
+    PolymorphicParentModelAdmin,
+    ImportExportModelAdmin,
+    TabbedTranslationAdmin,
+    AdminImageMixin
+    ):
     """
     Django admin customization for the Tutorial model.
 
@@ -25,6 +31,12 @@ class TutorialAdmin(ImportExportModelAdmin, TabbedTranslationAdmin, AdminImageMi
     """
 
     resource_class = TutorialResource
+    base_model = Tutorial
+    show_in_index = True
+    child_models = (
+        PictureTutorial,
+        VideoTutorial
+    )
 
     admin_priority = 2
     inlines = (TutorialFaqInline,)
@@ -77,33 +89,6 @@ class TutorialAdmin(ImportExportModelAdmin, TabbedTranslationAdmin, AdminImageMi
             },
         ),
         (
-            "SEO Metadata",
-            {
-                "fields": (
-                    "keywords",
-                    "meta_description",
-                    "json_ld",
-                ),
-                "classes": ("collapse",),
-            },
-        ),
-        (
-            "Open Graph Metadata",
-            {
-                "fields": (
-                    "og_title",
-                    "og_type",
-                    "og_image",
-                    "og_description",
-                    "og_url",
-                    "og_site_name",
-                    "og_locale",
-                    "article_author",
-                ),
-                "classes": ("collapse",),
-            },
-        ),
-        (
             _("Tags & Relationships"),
             {
                 "fields": (
@@ -146,3 +131,123 @@ class TutorialAdmin(ImportExportModelAdmin, TabbedTranslationAdmin, AdminImageMi
         queryset = super().get_queryset(request)
         queryset = queryset.prefetch_related("tags")
         return queryset
+
+
+@admin.register(PictureTutorial)
+class PictureTutorialAdmin(PolymorphicChildModelAdmin):
+    """
+    Django admin customization for the Tutorial model.
+
+    This admin class customizes the display, search, and filter capabilities for Tutorials
+    in the Django admin interface. It also provides a customized form layout for
+    editing and adding new Tutorials.
+    """
+    base_model = PictureTutorial
+    show_in_index = True
+    readonly_fields = ("created_at", "modified_at", "slug")
+
+    fieldsets = (
+        (
+            "Basic Information",
+            {"fields": ("title", "slug", "category", "is_published")},
+        ),
+        (
+            "Content Details",
+            {
+                "fields": (
+                    "author",
+                    "summary",
+                    "description",
+                    "picture",
+                    "banner",
+                    "alternate_text",
+                )
+            },
+        ),
+        (
+            _("Tags & Relationships"),
+            {
+                "fields": (
+                    "tags",
+                    "suggested_tutorials",
+                    "related_tutorials",
+                ),
+                "classes": ("collapse",),
+                "description": _(
+                    "Enhance the tutorial's visibility by adding tags and "
+                    "linking related tutorials."
+                ),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "fields": (
+                    "published_at",
+                    "modified_at",
+                    "created_at",
+                ),
+                "classes": ("collapse",),
+            },
+        ),
+    )
+
+
+@admin.register(VideoTutorial)
+class VideoTutorialAdmin(PolymorphicChildModelAdmin):
+    """
+    Django admin customization for the Tutorial model.
+
+    This admin class customizes the display, search, and filter capabilities for Tutorials
+    in the Django admin interface. It also provides a customized form layout for
+    editing and adding new Tutorials.
+    """
+    base_model = VideoTutorial
+    show_in_index = True
+    readonly_fields = ("created_at", "modified_at", "slug")
+
+    fieldsets = (
+        (
+            "Basic Information",
+            {"fields": ("title", "slug", "category", "is_published")},
+        ),
+        (
+            "Content Details",
+            {
+                "fields": (
+                    "author",
+                    "summary",
+                    "description",
+                    "video",
+                    "thumbnail",
+                    "alternate_text",
+                )
+            },
+        ),
+        (
+            _("Tags & Relationships"),
+            {
+                "fields": (
+                    "tags",
+                    "suggested_tutorials",
+                    "related_tutorials",
+                ),
+                "classes": ("collapse",),
+                "description": _(
+                    "Enhance the tutorial's visibility by adding tags and "
+                    "linking related tutorials."
+                ),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "fields": (
+                    "published_at",
+                    "modified_at",
+                    "created_at",
+                ),
+                "classes": ("collapse",),
+            },
+        ),
+    )

--- a/sage_ticket/models/__init__.py
+++ b/sage_ticket/models/__init__.py
@@ -3,7 +3,7 @@ from .comment import Comment
 from .department import Department
 from .issue import Issue
 from .faq import Faq, FaqCategory
-from .tutorial import Tutorial
+from .tutorial import Tutorial, PictureTutorial, VideoTutorial
 from .tutorial_faq import TutorialFaq
 from .category import TutorialCategory
 from .tag import TutorialTag
@@ -19,4 +19,6 @@ __all__ = [
     "TutorialFaq",
     "TutorialCategory",
     "TutorialTag",
+    "PictureTutorial",
+    "VideoTutorial",
 ]

--- a/sage_ticket/models/tutorial.py
+++ b/sage_ticket/models/tutorial.py
@@ -16,6 +16,7 @@ try:
     import readtime
 except ImportError:
     raise ImportError("Install `readtime` package. Run `pip install readtime` ")
+from polymorphic.models import PolymorphicModel
 
 from sage_tools.mixins.models.abstract import PictureOperationAbstract
 from sage_tools.mixins.models.base import TimeStampMixin, TitleSlugDescriptionMixin
@@ -24,8 +25,8 @@ from sage_ticket.repository.manager import TutorialDataAccessLayer
 
 
 class Tutorial(
+    PolymorphicModel,
     TitleSlugDescriptionMixin,
-    PictureOperationAbstract,
     TimeStampMixin,
 ):
     """
@@ -58,28 +59,6 @@ class Tutorial(
         blank=False,
         help_text=_("Enter a brief summary of the tutorial, up to 140 characters."),
         db_comment="A brief summary of the blog tutorial.",
-    )
-
-    picture = ImageField(
-        _("Picture of Tutorial"),
-        upload_to="blog/tutorials/pictures/",
-        width_field="width_field",
-        height_field="height_field",
-        help_text=_(
-            "Upload an image representing the tutorial. Ideal dimensions are [x] by [y]."
-        ),
-        db_comment="Image file associated with the blog tutorial.",
-    )
-
-    banner = ImageField(
-        _("Banner of Tutorial Detail"),
-        upload_to="blog/tutorials/banners/",
-        null=True,
-        blank=True,
-        help_text=_(
-            "Upload an image representing the tutorial. Ideal dimensions are [x] by [y]."
-        ),
-        db_comment="Image file associated with the blog tutorial.",
     )
 
     published_at = models.DateTimeField(
@@ -172,3 +151,56 @@ class Tutorial(
         printed or logged, especially during debugging.
         """
         return f"<Tutorial: {self.title}>"
+
+class PictureTutorial(Tutorial, PictureOperationAbstract):
+    """
+    Tutorial with picture and banner fields.
+    """
+    picture = ImageField(
+        _("Picture of Tutorial"),
+        upload_to="tutorials/pictures/",
+        null=True,
+        blank=True,
+        help_text=_("Upload an image representing the tutorial."),
+        db_comment="Image file associated with the tutorial.",
+    )
+    banner = ImageField(
+        _("Banner of Tutorial"),
+        upload_to="tutorials/banners/",
+        null=True,
+        blank=True,
+        help_text=_("Upload a banner image for the tutorial."),
+        db_comment="Banner image file associated with the tutorial.",
+    )
+
+    class Meta:
+        verbose_name = _("Picture Tutorial")
+        verbose_name_plural = _("Picture Tutorials")
+        db_table = "picture_tutorial"
+        db_table_comment = "Table for tutorials with pictures and banners."
+
+
+class VideoTutorial(Tutorial, PictureOperationAbstract):
+    """
+    Tutorial with a video field.
+    """
+    video = models.FileField(
+        _("Video File"),
+        upload_to="tutorials/videos/",
+        help_text=_("Upload the video file for the tutorial."),
+        db_comment="File of the video associated with the tutorial.",
+    )
+    thumbnail = ImageField(
+        _("Thumbnail of Tutorial"),
+        upload_to="tutorials/pictures/",
+        null=True,
+        blank=True,
+        help_text=_("Upload an image representing thumbnail of the tutorial."),
+        db_comment="Image file associated with the tutorial.",
+    )
+
+    class Meta:
+        verbose_name = _("Video Tutorial")
+        verbose_name_plural = _("Video Tutorials")
+        db_table = "video_tutorial"
+        db_table_comment = "Table for tutorials with video files."

--- a/sage_ticket/repository/manager/tutorial.py
+++ b/sage_ticket/repository/manager/tutorial.py
@@ -1,9 +1,9 @@
-from django.db.models import Manager
+from polymorphic.managers import PolymorphicManager
 
 from ..queryset.tutorial import TutorialQuerySet
 
 
-class TutorialDataAccessLayer(Manager):
+class TutorialDataAccessLayer(PolymorphicManager):
     """
     Tutorial Data Access Layer
     """

--- a/sage_ticket/repository/queryset/tutorial.py
+++ b/sage_ticket/repository/queryset/tutorial.py
@@ -19,8 +19,10 @@ from django.db.models import (
 from django.db.models.functions import Now
 from django.utils import timezone
 
+from polymorphic.query import PolymorphicQuerySet
 
-class TutorialQuerySet(QuerySet):
+
+class TutorialQuerySet(PolymorphicQuerySet):
     """
     A custom QuerySet class for the Tutorial model, providing additional methods for
     querying blog tutorials.

--- a/sage_ticket/translation/tutorial.py
+++ b/sage_ticket/translation/tutorial.py
@@ -12,4 +12,4 @@ class TutorialTranslationOptions(TranslationOptions):
     Tutorial Category Translation Option
     """
 
-    fields = ("title", "description", "summary", "alternate_text")
+    fields = ("title", "description", "summary")


### PR DESCRIPTION
… model

- Added `django-polymorphic` package to the project to enable polymorphic behavior for the `Tutorial` model.
- Updated `Tutorial` model and its derived models (`PictureTutorial` and `VideoTutorial`) to inherit from `PolymorphicModel`.
- Enhanced admin for `Tutorial`:
  - Registered `Tutorial` as a polymorphic parent model with separate admin views for child models.
  - Updated `TutorialFaqInline` for polymorphic compatibility.
- Refactored custom querysets and managers:
  - Inherited from `PolymorphicQuerySet` and `PolymorphicManager` to retain custom query logic while leveraging `django-polymorphic` capabilities.
- Updated dependencies in `poetry.lock` and `pyproject.toml` to include `django-polymorphic`.
- Adjusted translations and field handling to align with polymorphic changes