### PR TITLE
feat(forms): add `IssueForm` and `CommentForm` for improved form hand…

### DIFF
--- a/sage_ticket/forms/__init__.py
+++ b/sage_ticket/forms/__init__.py
@@ -1,0 +1,2 @@
+from .comment import CommentForm
+from .issue import IssueForm

--- a/sage_ticket/forms/comment.py
+++ b/sage_ticket/forms/comment.py
@@ -1,0 +1,29 @@
+from django import forms
+from sage_ticket.models import Comment
+
+
+class CommentForm(forms.ModelForm):
+    class Meta:
+        model = Comment
+        fields = ['title', 'message']
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        self.issue = kwargs.pop('issue', None)
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+
+        if self.user:
+            instance.user = self.user
+
+        if self.issue:
+            instance.issue = self.issue
+
+        instance.is_read = False
+
+        if commit:
+            instance.save()
+
+        return instance

--- a/sage_ticket/forms/issue.py
+++ b/sage_ticket/forms/issue.py
@@ -1,0 +1,27 @@
+from django import forms
+from sage_ticket.models import Issue
+from sage_ticket.helper.choice import TicketStateEnum
+
+
+class IssueForm(forms.ModelForm):
+    class Meta:
+        model = Issue
+        fields = ['subject', 'message', 'severity', 'department']
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+
+        if self.user:
+            instance.raised_by = self.user
+
+        instance.state = TicketStateEnum.NEW
+        instance.is_unread = True
+
+        if commit:
+            instance.save()
+
+        return instance


### PR DESCRIPTION
…ling

- Introduced `IssueForm` to streamline the creation of issues in the system:
  - Includes fields: `subject`, `message`, `severity`, `department`.
  - Automatically sets the `raised_by` field to the current user if provided.
  - Initializes `state` to `NEW` and marks the issue as unread by default.

- Introduced `CommentForm` to handle comment creation with relevant associations:
  - Includes fields: `title`, `message`.
  - Automatically links the comment to the user and issue if provided.
  - Sets `is_read` to `False` by default.